### PR TITLE
fix jittering at the end of sliding from max slope

### DIFF
--- a/Assets/Scripts/Movement.cs
+++ b/Assets/Scripts/Movement.cs
@@ -247,6 +247,17 @@ public class Movement : BoxColliderCasts
 				SlideDownMaxSlope(maxSlopeHitRight, ref displacement);
 			}
 		}
+				else if(maxSlopeHitLeft && maxSlopeHitRight)
+        {
+			if( maxSlopeHitLeft.distance < maxSlopeHitRight.distance )
+			{
+				SlideDownMaxSlope( maxSlopeHitLeft , ref displacement );
+			}
+			else
+            {
+                SlideDownMaxSlope( maxSlopeHitRight , ref displacement ); 
+            }
+        }
 
 		if (!slidingDownMaxSlope)
 		{


### PR DESCRIPTION
when slidng from slope at the end, rays dont work correctly because only one is being used and this causes the"ground" or diffrent platform to be detected and only it, then grounded state is applied which kills momentum, this simple change fixes it.